### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Using RWPromise is exactly same as using promise in js. `resolve` and `reject` a
 
 For more infomation about the API of promise in js, please reference [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 
-###Suppoted API
+### Suppoted API
 #### 0.1.0
 - `then`
 - `catch`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
